### PR TITLE
Upgrade for Endwalker Dalamud changes

### DIFF
--- a/PixelPerfect/PixelPerfect.csproj
+++ b/PixelPerfect/PixelPerfect.csproj
@@ -7,14 +7,17 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <Reference Include="Dalamud, Version=6.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>C:\Users\Haplo\AppData\Roaming\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
+      <Reference Include="Dalamud, Version=6.2.0.6, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
+        <Private>false</Private>
       </Reference>
       <Reference Include="ImGui.NET, Version=1.82.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>C:\Users\Haplo\AppData\Roaming\XIVLauncher\addon\Hooks\dev\ImGui.NET.dll</HintPath>
+        <HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\ImGui.NET.dll</HintPath>
+        <Private>false</Private>
       </Reference>
       <Reference Include="ImGuiScene, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>C:\Users\Haplo\AppData\Roaming\XIVLauncher\addon\Hooks\dev\ImGuiScene.dll</HintPath>
+        <HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\ImGuiScene.dll</HintPath>
+        <Private>false</Private>
       </Reference>
     </ItemGroup>
 


### PR DESCRIPTION
* Changed Dalamud Reference Version to 6.2.0.6
* Changed HintPath to use `$(AppData)` instead of hardcoded path
* Added Private false node to Reference [per development faq](https://goatcorp.github.io/faq/development#q-how-do-i-fix-nothing-inherits-from-idalamudplugin)