### PR TITLE
Update Dalamud version to 6.4.0.3 (latest).

### DIFF
--- a/PixelPerfect/PixelPerfect.csproj
+++ b/PixelPerfect/PixelPerfect.csproj
@@ -3,11 +3,11 @@
     <PropertyGroup>
         <TargetFramework>net5.0</TargetFramework>
         <Authors>Haplo064</Authors>
-        <Version>1.4.0.2</Version>
+        <Version>1.4.0.3</Version>
     </PropertyGroup>
 
     <ItemGroup>
-      <Reference Include="Dalamud, Version=6.2.0.6, Culture=neutral, PublicKeyToken=null">
+      <Reference Include="Dalamud, Version=6.4.0.3, Culture=neutral, PublicKeyToken=null">
         <HintPath>$(AppData)\XIVLauncher\addon\Hooks\dev\Dalamud.dll</HintPath>
       </Reference>
       <Reference Include="ImGui.NET, Version=1.82.0.0, Culture=neutral, PublicKeyToken=null">


### PR DESCRIPTION
Dalamud version was updated to 6.4.0.3 with the latest FFXIV patch (6.1), so updating the version to match.

Not sure if having version specified is necessary, but it's there, so I'm just updating it rather than removing it.