### PR TITLE
Fix canvas stealing focus when zoning

### DIFF
--- a/PixelPerfect/Doodles.cs
+++ b/PixelPerfect/Doodles.cs
@@ -20,7 +20,7 @@ namespace PixelPerfect
             ImGuiHelpers.SetNextWindowPosRelativeMainViewport(new Vector2(0, 0));
             ImGui.Begin("Canvas",
                 ImGuiWindowFlags.NoInputs | ImGuiWindowFlags.NoNav | ImGuiWindowFlags.NoTitleBar |
-                ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoBackground);
+                ImGuiWindowFlags.NoScrollbar | ImGuiWindowFlags.NoBackground | ImGuiWindowFlags.NoFocusOnAppearing);
             ImGui.SetWindowSize(ImGui.GetIO().DisplaySize);
 
             foreach (var doodle in _doodleBag)


### PR DESCRIPTION
Currently, when zoning and during certain other events, the reappearance of the canvas can steal focus from other imgui elements. As an example, if we were to open a Wotsit search while loading into a new zone, the canvas' reappearance when zoning ends causes the Wotsit search to lose focus and close.

By setting this flag, we avoid the problem. As far as I'm aware it's not necessary for the canvas to ever actually have focus, so I don't think this should cause any other issues, but please correct me if I'm wrong on that point.

Thank you.