### PR TITLE
Disable rendering when in an combat cutscene

### DIFF
--- a/PixelPerfect/Doodles.cs
+++ b/PixelPerfect/Doodles.cs
@@ -26,6 +26,8 @@ namespace PixelPerfect
             foreach (var doodle in _doodleBag)
             {
                 if (!doodle.Enabled) continue;
+                
+                if (_condition[ConditionFlag.Occupied38]) continue; // is in-combat cutscene
 
                 if (!CheckJob(_cs.LocalPlayer.ClassJob.RowId, doodle.JobsBool)) continue;
                 


### PR DESCRIPTION
This disables all doodles when the payer has lost camera control, aka is in a in-combat cutscene. I have tested about every duty I can think of, and this works in all of them. It also does not cause any issues in normal circumstances as `Occupied38` is only for the loss of camera control part, not down for the count, "in event" or other stuns.

Duties semi-easy to test: 
- The Dark Inside
- Alexander - The Heart of the Creator
- The Royal Menagerie
- Abyssos: The Fifth Circle